### PR TITLE
Allow '_' to route variable

### DIFF
--- a/lib/easymock.js
+++ b/lib/easymock.js
@@ -70,7 +70,7 @@ MockServer.prototype.readConfig = function() {
         }
         var route2 = {
           route: route.replace(regexp, '*'),
-          matcher: new RegExp('^' + route.replace(regexp, '([0-9a-zA-Z]+)').replace(/\//g, '\\/') + '$'),
+          matcher: new RegExp('^' + route.replace(regexp, '([0-9a-zA-Z_]+)').replace(/\//g, '\\/') + '$'),
           path: route.replace(/:/g, ''),
           params: params
         };

--- a/test/mock.test.coffee
+++ b/test/mock.test.coffee
@@ -141,6 +141,12 @@ describe 'Mock Server', ->
         json[1].id.should.equal 52
         json[1].nested.id.should.equal 52
         done()
+    it '/groups/mock_data should supply a #{id} variable that gets replaced', (done) ->
+      request 'get', '/groups/mock_data', (res) ->
+        res.statusCode.should.equal 200
+        json = JSON.parse res.body
+        json.name2.should.equal 'Group mock_data'
+        done()
     it '/groups should not forward to /groups/', (done) ->
       request 'get', '/groups', (res) ->
         res.statusCode.should.equal 200


### PR DESCRIPTION
I want to specify '_' to route variable.

```
/users/koba_04
```

This pull request allows '_' to route variable.
