### PR TITLE
Allow to pass to constructor config as object

### DIFF
--- a/lib/easymock.js
+++ b/lib/easymock.js
@@ -49,7 +49,7 @@ MockServer.prototype.ensureOptions = function() {
   this.options.config = this.options.config || this.options.path + '/config.json';
 
   // Use default config if none is provided
-  if (!fs.existsSync(this.options.config)) {
+  if (_.isString(this.options.config) && !fs.existsSync(this.options.config)) {
     this.options.config = __dirname + '/config.json';
   }
 };
@@ -59,7 +59,10 @@ MockServer.prototype.readConfig = function() {
   var now = new Date().getTime();
   if (!this.config_last_read || this.config_last_read < now - 2000) {
     this.config_last_read = now;
-    var config = JSON.parse(fs.readFileSync(this.options.config, 'utf8'));
+    var config = this.options.config;
+    if (_.isString(this.options.config)) {
+      config = JSON.parse(fs.readFileSync(this.options.config, 'utf8'));
+    }
     if (config.routes) {
       var regexp = /:[a-zA-Z_]*/g;
       config.routes = _.map(config.routes, function(route) {

--- a/test/mock.test.coffee
+++ b/test/mock.test.coffee
@@ -165,3 +165,24 @@ describe 'Mock Server', ->
         res.headers.should.have.property 'location'
         res.headers['location'].should.equal 'http://www.cyberagent.co.jp'
         done();
+
+describe 'Mock Server create with config object', ->
+  mock = undefined
+  beforeEach ->
+    config = {
+      variables : {
+        server: "http://config.server.com"
+      }
+    }
+    mock = new MockServer({ port: utils.TESTING_PORT, log_enabled: false, path: __dirname + '/mock_data/', config: config })
+    mock.start()
+  afterEach ->
+    mock.stop()
+
+  it 'should be used config variable', (done) ->
+    request 'get', '/with_variable', (res) ->
+      res.statusCode.should.equal 200
+      json = JSON.parse res.body
+      json.should.have.property 'image'
+      json.image.should.equal 'http://config.server.com/image.jpg'
+      done()


### PR DESCRIPTION
I am creating 'grunt-easymock' library.

I want to pass to constructor config as object .

```
mock = new MockServer({
  port: 3000,
  path: "path/to/dir",
  config: {
    variables: {
      server: "http://example.com"
    },
    routes: [
      "/users/:id"
    ],
  }
});
```

Of course, It can pass to file path.

```
mock = new MockServer({
  port: 3000,
  path: "path/to/dir",
  config: "path/to/config.json"
});
```
