### PR TITLE
Allow any route variable

### DIFF
--- a/lib/easymock.js
+++ b/lib/easymock.js
@@ -79,7 +79,7 @@ MockServer.prototype.readConfig = function() {
         }
         var route2 = {
           route: route.replace(regexp, '*'),
-          matcher: new RegExp('^' + route.replace(regexp, '([0-9a-zA-Z_]+)').replace(/\//g, '\\/') + '$'),
+          matcher: new RegExp('^' + route.replace(regexp, '([^/?]+)').replace(/\//g, '\\/') + '$'),
           path: route.replace(/:/g, ''),
           params: params
         };

--- a/test/mock.test.coffee
+++ b/test/mock.test.coffee
@@ -141,11 +141,11 @@ describe 'Mock Server', ->
         json[1].id.should.equal 52
         json[1].nested.id.should.equal 52
         done()
-    it '/groups/mock_data should supply a #{id} variable that gets replaced', (done) ->
-      request 'get', '/groups/mock_data', (res) ->
+    it '/groups/mock_data-1 should supply a #{id} variable that gets replaced', (done) ->
+      request 'get', '/groups/mock_data-1', (res) ->
         res.statusCode.should.equal 200
         json = JSON.parse res.body
-        json.name2.should.equal 'Group mock_data'
+        json.name2.should.equal 'Group mock_data-1'
         done()
     it '/groups should not forward to /groups/', (done) ->
       request 'get', '/groups', (res) ->


### PR DESCRIPTION
I want to use '-' in route variable.

like.

```
/users/koba-04
```

This pull request allows any route variable(except '/' and '?').
(I was reference to Backbone.Router's RegExp.)
