### PR TITLE
sqlite3 version up

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
       , "jade":        "0.27.7"
       , "underscore":  "1.4.2"
       , "broware":     "0.1.0"
-      , "sqlite3":     "2.1.19"
+      , "sqlite3":     "2.2.3"
       , "moment":      "2.0.0"
       , "marked":      "0.2.10"
       , "commander":   "2.1.0"


### PR DESCRIPTION
npm ERR! sqlite3@2.1.19 install: `node build.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the sqlite3@2.1.19 install script.
npm ERR! This is most likely a problem with the sqlite3 package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node build.js
npm ERR! You can get their info via:
npm ERR!     npm owner ls sqlite3
npm ERR! There is likely additional logging output above.
