### PR TITLE
Do not logging to sqlite when log_enabled is false

### DIFF
--- a/lib/access_log.js
+++ b/lib/access_log.js
@@ -35,7 +35,7 @@ AccessLog.prototype.insertDb = function(req, resStatus, resHeaders, resBody) {
     'VALUES (?,?,?,?,?,?,?,?)', [ req.connection.remoteAddress, req.method.toUpperCase(), req.url, requestHeaders, requestBody, resStatus, resHeaders, resBody ]);
 };
 
-AccessLog.prototype.ensureCreation = function() {
+AccessLog.prototype.ensureCreation = function(callback) {
   this.db.run('CREATE TABLE IF NOT EXISTS logs (' +
     '_id INTEGER PRIMARY KEY AUTOINCREMENT,' +
     'time DATETIME DEFAULT CURRENT_TIMESTAMP,' +
@@ -47,7 +47,7 @@ AccessLog.prototype.ensureCreation = function() {
     'response_status INTEGER,' +
     'response_headers TEXT,' +
     'response_body TEXT' +
-    ')');
+    ')', callback);
 };
 
 AccessLog.prototype.insert = function(req, status, body) {

--- a/lib/easymock.js
+++ b/lib/easymock.js
@@ -18,7 +18,9 @@ exports.version = require('../package').version;
 function MockServer(options) {
   this.options = options;
   this.ensureOptions();
-  this.log = new AccessLog();
+  if (this.options.log_enabled) {
+    this.log = new AccessLog();
+  }
 }
 
 MockServer.prototype.start = function() {
@@ -220,10 +222,14 @@ MockServer.prototype.handleAnyRequest = function(req, res){
   if (!fs.existsSync(info.file)) {
     var staticFile = mock.options.path + url.parse(req.url).pathname;
     if (fs.existsSync(staticFile)) {
-      mock.log.insert(req, 200, 'File contents');
+      if (mock.options.log_enabled) {
+        mock.log.insert(req, 200, 'File contents');
+      }
       return res.sendfile(staticFile);
     } else {
-      mock.log.insert(req, 404, '');
+      if (mock.options.log_enabled) {
+        mock.log.insert(req, 404, '');
+      }
       return res.send(404);
     }
   }
@@ -245,7 +251,9 @@ MockServer.prototype.handleAnyRequest = function(req, res){
   }
   var statusCode = error ? error.response.status : data.response.status;
   res.set(data.response.headers);
-  mock.log.insert(req, statusCode, body);
+  if (mock.options.log_enabled) {
+    mock.log.insert(req, statusCode, body);
+  }
   res.send(statusCode, body);
 };
 
@@ -523,7 +531,11 @@ MockServer.prototype.getApiDocumentation = function(req, res) {
 };
 
 MockServer.prototype.getLogs = function(req, res) {
-  res.app.set('mock').log.getLogs(function(err, logs) {
+  var mock = res.app.set('mock');
+  if (!mock.options.log_enabled) {
+    return res.send(400, "log_disabled");
+  }
+  mock.log.getLogs(function(err, logs) {
     if (err) { return res.send(400, err); }
     logs = _.map(logs, function(log) {
       if (log.response_body &&

--- a/test/logs.test.coffee
+++ b/test/logs.test.coffee
@@ -7,9 +7,10 @@ request = utils.request
 describe 'Access Logs', ->
   mock = undefined
   beforeEach (done)->
-    mock = new MockServer({ port: utils.TESTING_PORT, log_enabled: false, path: __dirname + '/mock_data/' })
+    mock = new MockServer({ port: utils.TESTING_PORT, log_enabled: true, path: __dirname + '/mock_data/' })
     mock.start()
-    mock.log.clear(done)
+    mock.log.ensureCreation ->
+      mock.log.clear(done)
   afterEach ->
     mock.stop()
 


### PR DESCRIPTION
I specified false to log_enabled, but sqlite db was created and logging to the db.

I prefer to not logging to sqlite when log_enabled is false. (also create db too)

How about do you think?
