### PR TITLE
Fix diff response when path ends with or without slash

### DIFF
--- a/lib/easymock.js
+++ b/lib/easymock.js
@@ -313,7 +313,7 @@ MockServer.prototype.getRequestInfo = function(arg1, arg2) {
       }
     }
   }
-  if (!info.route) {
+  if (config['strict-mode'] && !info.route) {
     if (info.file.substr(-1) !== '/') {
       info.file += '/';
     }


### PR DESCRIPTION
This fixes the following problem:
- When a client makes a GET to `http://domain/api/apps`, easymock looks for `/api/apps_get.json`.
- But when a client makes a GET to `http://domain/api/apps/` _with an ending slash_, easymock looks for `/api/apps/_get.json`.

With this fix, easymock will always look for `/api/apps/_get.json`, which I think is much more clear.
