### PR TITLE
Delete a redeclaration of var fs

### DIFF
--- a/lib/easymock.js
+++ b/lib/easymock.js
@@ -2,7 +2,6 @@
 var express = require('express');
 var fs = require('fs');
 var url = require('url');
-var fs = require('fs');
 var httpProxy = require('http-proxy');
 var _ = require('underscore');
 var marked = require('marked');


### PR DESCRIPTION
Hi!

This patch deletes a redeclaration of `var fs` in `easymock.js`.