### PR TITLE
Add the variable QUERY_STRING.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Nested variables support: #{name_#{lang}} will resolve to #{name_de} for #{lang}
 
 Following variables are available by default:
 
-- #{HOST} -> Requested hostname (and port) of the request. For example ```localhost:3000``` or ```127.0.0.1```
+- `#{HOST}` -> Requested hostname (and port) of the request. For example ```localhost:3000``` or ```127.0.0.1```
+- `#{QUERY_STRING}` -> Complete query string of the request. For example ```foo=bar``` or ```a=b&c=d```
 
 Example to use variables. item_get.json:
 

--- a/lib/easymock.js
+++ b/lib/easymock.js
@@ -324,7 +324,7 @@ MockServer.prototype.getRequestInfo = function(arg1, arg2, args) {
       pathname = pathname.substr(0, pathname.length - 5);
     }
     method = arg1.method.toLowerCase();
-    args = {host:arg1.headers.host};
+    args = {host:arg1.headers.host, query_string:reqUrl.query};
   } else {
     method = arg1.toLowerCase();
     pathname = arg2;
@@ -337,6 +337,9 @@ MockServer.prototype.getRequestInfo = function(arg1, arg2, args) {
 
   if (args && args.host) {
     info.params.HOST = args.host;
+  }
+  if (args && args.query_string) {
+    info.params.QUERY_STRING = args.query_string;
   }
 
   var config = this.readConfig();

--- a/test/mock.test.coffee
+++ b/test/mock.test.coffee
@@ -126,6 +126,13 @@ describe 'Mock Server', ->
         json.should.have.property('path').and.equal 'http://localhost:' + utils.TESTING_PORT + '/path'
         done()
 
+    it '#{QUERY_STRING} should be replaced with the current request\'s query string', (done) ->
+      request 'get', '/with_variable_QUERY_STRING?foo=bar', (res) ->
+        res.statusCode.should.equal 200
+        json = JSON.parse res.body
+        json.should.have.property('query').and.equal 'foo=bar'
+        done()
+
     it '#{name_#lang} should be replaced correctly with #lang = de -> #{name_de} => Patrick', (done) ->
       request 'get', '/with_variable_within_variable?lang=de', (res) ->
         res.statusCode.should.equal 200

--- a/test/mock_data/with_variable_QUERY_STRING_get.json
+++ b/test/mock_data/with_variable_QUERY_STRING_get.json
@@ -1,0 +1,3 @@
+{
+  "query": "#{QUERY_STRING}"
+}


### PR DESCRIPTION
This can be useful when mocking out APIs that don't use any parameter names in the query string, e.g. `/cgi-bin/config?12345`.