### PR TITLE
Add the ability to use different lags depending on the request path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,45 @@ If you want to configure routes, proxy or lag, create a config.json file which l
           ]
         }
 
-If you want a random lag in responses, like in a real-world scenario, set simulated-lag-min and simulated-lag-max instead of simulated-lag (which would take precedence, though)
+### Simulating lag in responses
+To add the same lag to all responses, set simulated-lag to a number.
+
+    {
+      "simulated-lag": 1000
+    }
+
+If you want a random lag in responses, like in a real-world scenario, set
+simulated-lag-min and simulated-lag-max instead of simulated-lag. If
+simulated-lag is set, it will take precedence over simulated-lag-min and -max.
+
+#### Changing the simulated lag based on the path
+
+For more fine-grained control over lag in responses, specify an object for
+simulated-lag, as in the following example:
+
+    {
+      "simulated-lag": {
+        "default": 500,
+        "paths": [
+          {
+            "match": "^/users$",
+            "lag": 1000
+          },
+          {
+            "match": "^/users/.*",
+            "lag": 2000
+          },
+          {
+            "match": "no-lag",
+            "lag": 0
+          }
+        ]
+      }
+    }
+
+Each "match" value is turned into a regular expression (using `new RegExp`) and
+matched against the request path (which excludes the query string). The first
+match found in the "paths" array is the one used, so be careful with the order.
 
 ### Variables
 Variables that you define in your config.json can be used in files that have the \_get/\_post/... extension. As well you can use them in your templates.

--- a/lib/easymock.js
+++ b/lib/easymock.js
@@ -132,12 +132,31 @@ MockServer.prototype.startMock = function() {
   this.mock_server = app.listen(this.options.port + 1);
 };
 
-MockServer.prototype.generateLag = function() {
-  var config = this.readConfig();
-  var lagFixed = config['simulated-lag'];
+function findMatchingLag(lagconfig, path) {
+  if (_.isEmpty(lagconfig.paths)) {
+    return lagconfig.default || 0;
+  }
 
-  if(lagFixed) {
-    return lagFixed;
+  for (var i = 0; i < lagconfig.paths.length; i++) {
+    // Convert the match string to a RegExp object.
+    var pathobj = lagconfig.paths[i];
+
+    if (new RegExp(pathobj.match).test(path)) {
+      return pathobj.lag || 0;
+    }
+  }
+
+  return lagconfig.default;
+}
+
+MockServer.prototype.generateLag = function(requestPath) {
+  var config = this.readConfig();
+  var lag = config['simulated-lag'];
+  if (typeof(lag) === 'number') {
+    // Fixed lag.
+    return lag;
+  } else if (typeof(lag) === 'object') {
+    return findMatchingLag(lag, requestPath);
   }
 
   var lagMax = config['simulated-lag-max'];
@@ -193,7 +212,7 @@ MockServer.prototype.startProxy = function() {
           buffer: buffer
         });
       }
-    }, self.generateLag());
+    }, self.generateLag(reqUrl.pathname));
   }).listen(this.options.port);
 };
 

--- a/test/lag.test.coffee
+++ b/test/lag.test.coffee
@@ -45,3 +45,65 @@ describe 'Mock Server with random lag', ->
       lag.should.be.below 1100
       console.log
       done()
+
+describe 'Mock Server with lag object (lag on specific paths)', ->
+  mock = undefined
+  beforeEach ->
+    mock = new MockServer
+      port: utils.TESTING_PORT
+      log_enabled: false
+      path: __dirname + '/mock_data/'
+      config: __dirname + '/mock_data/config_with_lag_object.json'
+    mock.start()
+  afterEach ->
+    mock.stop()
+
+  it 'should add the default lag when there are no matches', (done) ->
+    start = new Date
+    request 'get', '/test1', (res) ->
+      end = new Date
+      lag = end.getTime() - start.getTime()
+      lag.should.be.above 1000
+      console.log
+      done()
+
+  it 'should add the lag for the first path matched', (done) ->
+    start = new Date
+    request 'get', '/laggy', (res) ->
+      end = new Date
+      lag = end.getTime() - start.getTime()
+      lag.should.be.above 500
+      lag.should.be.below 800
+      console.log
+      done()
+
+  describe 'should use regular expressions for matching', ->
+    it 'and use the lag for the first match found', (done) ->
+      start = new Date
+      request 'get', '/lag_is_fun/12345', (res) ->
+        end = new Date
+        lag = end.getTime() - start.getTime()
+        lag.should.be.above 200
+        lag.should.be.below 1000
+        console.log
+        done()
+
+    it 'and use the default lag if there are no matches', (done) ->
+      start = new Date
+      request 'get', '/lag_is_fun/but_this_wont_match', (res) ->
+        end = new Date
+        lag = end.getTime() - start.getTime()
+        lag.should.be.above 1000
+        console.log
+        done()
+
+    # Expression has [0-9]+ after the slash, so no content after the slash
+    # should result in a non-match.
+    it 'and use the default lag if there are no matches', (done) ->
+      start = new Date
+      request 'get', '/lag_is_fun/', (res) ->
+        end = new Date
+        lag = end.getTime() - start.getTime()
+        lag.should.be.above 1000
+        console.log
+        done()

--- a/test/mock_data/config_with_lag_object.json
+++ b/test/mock_data/config_with_lag_object.json
@@ -1,0 +1,24 @@
+
+{
+  "simulated-lag": {
+    "default": 1000,
+    "paths": [
+      {
+        "match": "^/dontmatchme$",
+        "lag": 5000
+      },
+      {
+        "match": "/laggy",
+        "lag": 500
+      },
+      {
+        "match": "^/laggy",
+        "lag": 800
+      },
+      {
+        "match": "^/lag_is_fun/[0-9]+$",
+        "lag": 200
+      }
+    ]
+  }
+}


### PR DESCRIPTION
It's not always useful to use the same simulated lag on all requests. This change lets you specify a different lag for different paths, matched via regular expression.