### PR TITLE
allow more than 1..9 parameters

### DIFF
--- a/lib/easymock.js
+++ b/lib/easymock.js
@@ -10,7 +10,7 @@ require('broware');
 
 var TEMPLATE_PATTERN = new RegExp(/"?\{\{([a-zA-Z0-9\-_]+)(\([^()]+\))?\}\}"?/g);
 var VARIABLE_PATTERN = new RegExp(/#\{[a-zA-Z0-9\-_]+\}/g);
-var PARAM_PATTERN    = new RegExp(/#\{_([1-9])\}/g);
+var PARAM_PATTERN    = new RegExp(/#\{_([1-9][0-9]*)\}/g);
 
 exports.version = require('../package').version;
 


### PR DESCRIPTION
parameters regex does not match expressions like "#{_10}" or greater.
parameter zero "#{_0}" remains unmatched, so this should not change
previous behaviour.