### PR TITLE
extend proxy path matching functions that not exact path matching(before) but path pattern 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea
 node_modules/
 lib-cov/
 coverage.html

--- a/lib/easymock.js
+++ b/lib/easymock.js
@@ -219,6 +219,69 @@ MockServer.prototype.startProxy = function() {
 };
 
 /**
+ * @param on {string} current url
+ * @param route {Object} route regexp to match the url against
+ * @return {?Object}
+ *
+ * @description
+ * Check if the route matches the current url.
+ *
+ * Inspired by match in
+ * visionmedia/express/lib/router/router.js.
+ * angular-router.js.
+ */
+function pathRegExp(path, opts) {
+  var insensitive = opts.caseInsensitiveMatch,
+      ret = {
+        originalPath: path,
+        regexp: path
+      },
+      keys = ret.keys = [];
+
+  path = path
+      .replace(/([().])/g, '\\$1')
+      .replace(/(\/)?:(\w+)([\?\*])?/g, function(_, slash, key, option) {
+        var optional = option === '?' ? option : null;
+        var star = option === '*' ? option : null;
+        keys.push({ name: key, optional: !!optional });
+        slash = slash || '';
+        return ''
+            + (optional ? '' : slash)
+            + '(?:'
+            + (optional ? slash : '')
+            + (star && '(.+?)' || '([^/]+)')
+            + (optional || '')
+            + ')'
+            + (optional || '');
+      })
+      .replace(/([\/$\*])/g, '\\$1');
+
+  ret.regexp = new RegExp('^' + path + '$', insensitive ? 'i' : '');
+  return ret;
+}
+
+function switchRouteMatcher(on, route) {
+  var keys = route.keys,
+      params = {};
+
+  if (!route.regexp) return null;
+
+  var m = route.regexp.exec(on);
+  if (!m) return null;
+
+  for (var i = 1, len = m.length; i < len; ++i) {
+    var key = keys[i - 1];
+
+    var val = m[i];
+
+    if (key && val) {
+      params[key.name] = val;
+    }
+  }
+  return params;
+}
+
+/**
  * Call either with shouldProxy(req) or shouldProxy(path, method).
  */
 MockServer.prototype.shouldProxy = function(path, method) {
@@ -236,15 +299,19 @@ MockServer.prototype.shouldProxy = function(path, method) {
   var config = this.readConfig();
   if (config.proxy) {
     var defaultProxy = config.proxy['default'] || false;
-    if (config.proxy.calls && config.proxy.calls[path] !== undefined) {
-      var entry = config.proxy.calls[path];
-      if (typeof(entry) === 'object') {
-        if (typeof(entry[method]) === 'boolean') {
-          return entry[method];
+    if (config.proxy.calls) {
+      var entry, router;
+      for (var prop in config.proxy.calls) {
+        entry = config.proxy.calls[prop];
+        router = pathRegExp(prop, { caseInsensitiveMatch : false} );
+        if (switchRouteMatcher(path, router)) {
+          if (_.isObject(entry)) {
+            return _.isBoolean(entry[method]) ? entry[method] : defaultProxy;
+          }
+          if (_.isBoolean(entry)) {
+            return entry;
+          }
         }
-        return defaultProxy;
-      } else if (typeof(entry) === 'boolean') {
-        return entry;
       }
     } else {
       return defaultProxy;


### PR DESCRIPTION
extend proxy path matching functions that not exact path matching(before) but path pattern matching(after)
	- original source from angular-router.js

add gitignore intelj resources