### PR TITLE
config.jsonに"response_headers"を書けるようにする。

### DIFF
--- a/lib/easymock.js
+++ b/lib/easymock.js
@@ -317,7 +317,7 @@ MockServer.prototype.handleAnyRequest = function(req, res){
     }
   }
   var statusCode = error ? error.response.status : data.response.status;
-  res.set(data.response.headers);
+  res.set(_.extend(data.response.headers, config.response_headers || {}));
   if (mock.options.log_enabled) {
     mock.log.insert(req, statusCode, body);
   }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   , "description"   : "Easy to use mock server that supports templates and routes."
   , "keywords"      : ["server", "mock", "routes", "proxy"]
   , "author"        : "Patrick Boos <mail@pboos.ch>"
-  , "repository"    : {"type": "git", "url": "git://github.com/cyberagent/node-easymock.git"}
+  , "repository"    : {"type": "git", "url": "git://github.com/ch-hamo/node-easymock.git"}
   , "version"       : "0.2.15"
   , "main"          : "index"
   , "bin"           : { "easymock": "./bin/easymock" }


### PR DESCRIPTION
レスポンスを生成する処理において、オリジナルのレスポンスヘッダにconfig.response_headersを加える（非nullであれば）。

