### PR TITLE
Print mock port and proxy port when server is starting.

### DIFF
--- a/lib/easymock.js
+++ b/lib/easymock.js
@@ -28,6 +28,7 @@ MockServer.prototype.start = function() {
   if (this.options.log_enabled) {
     var serverUrl = 'http://localhost:' + this.options.port;
     console.log('Server running on ' + serverUrl);
+    console.log('Listening on port ' + this.options.port + ' and ' + (this.options.port + 1));
     console.log('Documentation at: ' + serverUrl + '/_documentation/');
     console.log('Logs at:          ' + serverUrl + '/_logs/');
   }
@@ -108,7 +109,7 @@ MockServer.prototype.startMock = function() {
     // If multipart form, ignore rawbody.
     // TODO instead just add the parameters and ignore the files
     var contentType = req.headers['content-type'] || "";
-    if (contentType.indexOf('multipart/form-data') < 0) { 
+    if (contentType.indexOf('multipart/form-data') < 0) {
       req.rawBody = '';
       req.setEncoding('utf8');
       req.on('data', function(chunk) { req.rawBody += chunk; });


### PR DESCRIPTION
I added `console.log` because I think we should tell users all of listening ports.