### PR TITLE
Access log location configurable and support Node v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@
 node_modules/
 lib-cov/
 coverage.html
-
 access_logs.db

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# EasyMock Server
+# Fakit Server
+i.e. easymock working also in Node v4 and some other stuff..
 
 ## Usage
 
-        $ npm install -g easymock
-        $ easymock
+        $ npm install -g fakit
+        $ fakit
 
 
 
@@ -193,7 +194,7 @@ Will respond with:
     connection: close
 
 ## Documentation
-easymock automatically documents the API it represents. This documentation can be extended by adding additional information like description, input info and output info to the json file. This is an example on how to do that for example in test_post.json:
+fakit automatically documents the API it represents. This documentation can be extended by adding additional information like description, input info and output info to the json file. This is an example on how to do that for example in test_post.json:
 
     # This is some documentation
     # This call creates an object
@@ -219,7 +220,7 @@ Can be enabled by setting either "jsonp" or "cors" or both to true in the config
 
 
 ## Errors
-Easymock can return errors defined in the documentation. the config.json set "error-rate": 0.5, to have a 50% error rate. So one out of 2 calls in average will return an error.
+Fakit can return errors defined in the documentation. the config.json set "error-rate": 0.5, to have a 50% error rate. So one out of 2 calls in average will return an error.
 To specify an error, first add a error json file in \_errors. For example "\_errors/not\_authenticated.json":
 
     < @status 401

--- a/lib/access_log.js
+++ b/lib/access_log.js
@@ -2,8 +2,8 @@
 var sqlite3 = require('sqlite3');
 var _ = require('underscore');
 
-function AccessLog() {
-  this.db = new sqlite3.Database('access_logs.db');
+function AccessLog(config) {
+  this.db = new sqlite3.Database(config.access_log || 'access_logs.db');
   this.ensureCreation();
 }
 

--- a/lib/easymock.js
+++ b/lib/easymock.js
@@ -18,7 +18,7 @@ function MockServer(options) {
   this.options = options;
   this.ensureOptions();
   if (this.options.log_enabled) {
-    this.log = new AccessLog();
+    this.log = new AccessLog(this.readConfig());
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   , "description"   : "Easy to use mock server that supports templates and routes."
   , "keywords"      : ["server", "mock", "routes", "proxy"]
   , "repository"    : {"type": "git", "url": "git://github.com/pihvi/node-easymock.git"}
-  , "version"       : "0.2.18"
+  , "version"       : "1.0.19"
   , "main"          : "index"
   , "bin"           : { "fakit": "./bin/easymock" }
   , "scripts" : {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
       , "jade":        "0.27.7"
       , "underscore":  "1.4.2"
       , "broware":     "0.1.0"
-      , "sqlite3":     "3.0.5"
+      , "sqlite3":     "3.1.0"
       , "moment":      "2.0.0"
       , "marked":      "0.3.2"
       , "commander":   "2.1.0"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
-    "name"          : "easymock"
+    "name"          : "fakit"
   , "description"   : "Easy to use mock server that supports templates and routes."
   , "keywords"      : ["server", "mock", "routes", "proxy"]
-  , "author"        : "Patrick Boos <mail@pboos.ch>"
-  , "repository"    : {"type": "git", "url": "git://github.com/cyberagent/node-easymock.git"}
-  , "version"       : "0.2.17"
+  , "repository"    : {"type": "git", "url": "git://github.com/pihvi/node-easymock.git"}
+  , "version"       : "0.2.18"
   , "main"          : "index"
-  , "bin"           : { "easymock": "./bin/easymock" }
+  , "bin"           : { "fakit": "./bin/easymock" }
   , "scripts" : {
         "test": "make tests"
     }


### PR DESCRIPTION
I got this with npm install:

npm ERR! notsup Unsupported
npm ERR! notsup Not compatible with your version of node/npm: sqlite3@3.0.5
npm ERR! notsup Required: {"node":">= 0.10.0 < 0.11.0 || >= 0.11.13 < 0.13.0 || >= 1.0.0 < 2.0.0"}
npm ERR! notsup Actual:   {"npm":"2.14.3","node":"4.1.0"}

The sqlite3 version did not support latest Node version. This commit fixes this and works on my machine :)