### PR TITLE
Enable parsing json format body when content type has '+json' suffix.

### DIFF
--- a/lib/easymock.js
+++ b/lib/easymock.js
@@ -1,7 +1,6 @@
 /*global require:true, exports:true, __dirname:true, process:true */
 var express = require('express');
 var bodyParser  = require('body-parser');
-var typeis = require('type-is'); // pulled in with body-parser
 var fs = require('fs');
 var url = require('url');
 var httpProxy = require('http-proxy');
@@ -112,10 +111,7 @@ MockServer.prototype.startMock = function() {
     next();
   });
   app.use(bodyParser.json({
-    type: function(req) {
-      return Boolean(typeis(req, 'application/json'))
-          || Boolean(typeis(req, 'application/vnd.api+json'));
-    }
+    type: ['application/json', 'application/*+json']
   }));
 
   app.locals.moment = require('moment');


### PR DESCRIPTION
HI.
When I send request which has `application/scim+json` value on content-type, the request body is not shown on access logs page.
![image](https://user-images.githubusercontent.com/5428401/34905025-0731a254-f894-11e7-90ee-a83834b20881.png)
This problem is caused by body parsing logic.
Existing logic only allows `application/json'` and `application/vnd.api+json`.

Mime type value which has `+json` suffix is allowed on (RFC6838)[https://tools.ietf.org/html/bcp13#section-4.2.8].
So, I think `.*+json` content-type request body should be also parsed.