### PR TITLE
Use default proxy setup when the path is not registered in calls

### DIFF
--- a/lib/easymock.js
+++ b/lib/easymock.js
@@ -316,6 +316,7 @@ MockServer.prototype.shouldProxy = function(path, method) {
           }
         }
       }
+      return defaultProxy;
     } else {
       return defaultProxy;
     }


### PR DESCRIPTION
In a proxy setup with the default key set to true not registered paths (in calls) are not being proxied but a 404 its returned.